### PR TITLE
Removed incorrect information

### DIFF
--- a/docs/source/tools/remix/index.rst
+++ b/docs/source/tools/remix/index.rst
@@ -41,7 +41,7 @@ Authentication
 
    .. figure:: img/mythxcreds2.png
 
-   .. note:: You need to link your Ethereum account to your MythX account to use MythX with Remix. See the :ref:`getting-started` page for more details.
+
 
 Usage
 -----


### PR DESCRIPTION
I removed the text "You need to link your Ethereum account to your MythX account to use MythX with Remix. See the :ref:`getting-started` page for more details." as this not correct user use their API key to connect Remix to the MythX account.